### PR TITLE
add startup log, indicate that service is up.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ armv6: [![Docker Pulls](https://img.shields.io/docker/pulls/hellstein/ssh-rpc-ag
 ![Travis (.org) branch](https://img.shields.io/travis/hellstein/ssh-rpc-agent/master.svg)
 ![GitHub](https://img.shields.io/github/license/hellstein/ssh-rpc-agent.svg)
 
-# [Quick started](https://hellstein.github.io/ssh-rpc-agent/usage/quickstart/Video.html)
+# [Quick start](https://hellstein.github.io/ssh-rpc-agent/usage/quickstart/Video.html)
 
 ### Get release and unzip
 ```

--- a/gitbook/usage/devguide/HowToStart.md
+++ b/gitbook/usage/devguide/HowToStart.md
@@ -20,7 +20,7 @@ go build
 You will see a binary file called `ssh-rpc-agent` generated.
 
 ### Start server 
-Start server by excuting `./ssh-rpc-agent`. Server is listening on port `8900` by default.
+Start server by executing `./ssh-rpc-agent`. Server is listening on port `8900` by default.
 
 ### Run client
 * Go to client env

--- a/starter.go
+++ b/starter.go
@@ -7,5 +7,6 @@ import (
 
 func main() {
     mgr := &jobmgr.Mgr{}
+    log.Println("Serving Agent on 0.0.0.0 port 8900 ...")
     log.Fatal(http.ListenAndServe(":8900", CreateRouter(mgr)))
 }

--- a/wsclient/test.sh
+++ b/wsclient/test.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 DIR=${HOME}/gowork/src/github.com/hellstein/ssh-rpc-agent/wsclient/example
-nodejs client.js --url localhost:8900/test --machineFile ${DIR}/machine-${1}.json --taskFile=${DIR}/tasks.json
+node client.js --url localhost:8900/test --machineFile ${DIR}/machine-${1}.json --taskFile=${DIR}/tasks.json


### PR DESCRIPTION
add startup log, indicate that service is up. 

`./ssh-rpc-agent` output:
```
2018/12/13 14:09:33 Serving Agent on 0.0.0.0 port 8900 ...
```